### PR TITLE
Added the apply to file options page

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,6 +5,9 @@ const { str, url, bool, port } = Validators;
 export const env = readEnv(process.env, {
     API_URL: url.describe("API base URL for service interaction"),
     APP_NAME: str.describe("Name of the application").default("presenter-account-web"),
+    APPLICATION_FORM_LINK: str
+        .default("https://www.gov.uk/government/publications/apply-for-a-companies-house-online-filing-presenter-account")
+        .describe("Link to complete an application form"),
     CACHE_SERVER: str.describe("Cache server URL"),
     CDN_HOST: str.map(addProtocolIfMissing).describe("URL for the CDN"),
     CDN_URL_CSS: str.describe("CDN URL for the CSS files").default("/css"),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,15 +3,19 @@ export const servicePathPrefix = "/presenter-account";
 export const Urls = {
     HOME: "/",
     HEALTHCHECK: "/healthcheck",
+    APPLY_TO_FILE_OPTIONS: "/what-do-you-need-to-file",
     ENTER_YOUR_DETAILS: "/enter-your-details",
     CHECK_DETAILS: "/check_details",
-    SUBMITTED: "/submitted"
+    SUBMITTED: "/submitted",
+    YOU_CANNOT_USE_THIS_SERVICE: '/you-cannot-use-this-service'
 };
 
 export const PrefixedUrls = {
     HOME: servicePathPrefix + Urls.HOME,
+    APPLY_TO_FILE_OPTIONS: servicePathPrefix + Urls.APPLY_TO_FILE_OPTIONS,
     HEALTHCHECK: servicePathPrefix + Urls.HEALTHCHECK,
     ENTER_YOUR_DETAILS: servicePathPrefix + Urls.ENTER_YOUR_DETAILS,
     CHECK_DETAILS: servicePathPrefix + Urls.CHECK_DETAILS,
-    SUBMITTED: servicePathPrefix + Urls.SUBMITTED
+    SUBMITTED: servicePathPrefix + Urls.SUBMITTED,
+    YOU_CANNOT_USE_THIS_SERVICE: servicePathPrefix + Urls.YOU_CANNOT_USE_THIS_SERVICE
 };

--- a/src/router.dispatch.ts
+++ b/src/router.dispatch.ts
@@ -1,6 +1,6 @@
 // Do Router dispatch here, i.e. map incoming routes to appropriate router
 import { Application, Router } from "express";
-import { HomeRouter, HealthCheckRouter, CheckDetailsRouter } from "./routers";
+import { HomeRouter, HealthCheckRouter, CheckDetailsRouter, ApplyToFileOptionsRouter, YouCannotUseThisServiceRouter } from "./routers";
 import { errorHandler, pageNotFound } from "./routers/handlers/errors";
 import { sessionMiddleware } from "./middleware/session.middleware";
 import { authenticationMiddleware } from "./middleware/authentication.middleware";
@@ -14,6 +14,8 @@ const routerDispatch = (app: Application) => {
 
     router.use(Urls.HOME, HomeRouter);
     router.use(Urls.HEALTHCHECK, HealthCheckRouter);
+    router.use(Urls.APPLY_TO_FILE_OPTIONS, ApplyToFileOptionsRouter);
+    router.use(Urls.YOU_CANNOT_USE_THIS_SERVICE, YouCannotUseThisServiceRouter);
 
     router.use("/", sessionMiddleware);
 
@@ -21,7 +23,7 @@ const routerDispatch = (app: Application) => {
     const userAuthRegex = /^\/.+/;
     router.use(userAuthRegex, authenticationMiddleware);
 
-    router.use(CheckDetailsRouter);
+    router.use(Urls.CHECK_DETAILS, CheckDetailsRouter);
 
     // TODO: this endpoint is a dummy authenticated endpoint used for testing AOAF-280. Remove this endpoint once AOAF-280 has completed testing.
     router.get('/post-sign', (req, res) => {

--- a/src/routers/apply.to.file.options.router.ts
+++ b/src/routers/apply.to.file.options.router.ts
@@ -1,0 +1,19 @@
+import { Request, Response, Router, NextFunction } from "express";
+import { ApplyToFileOptionsHandler } from "./handlers/apply_to_file_options";
+
+const router: Router = Router();
+
+router.get("/", (req: Request, res: Response, _next: NextFunction) => {
+    const handler = new ApplyToFileOptionsHandler();
+    const { templatePath, viewData } = handler.executeGet(req, res);
+    res.render(templatePath, viewData);
+});
+
+router.post("/", (req: Request, res: Response, _next: NextFunction) => {
+    const handler = new ApplyToFileOptionsHandler();
+    const { redirect } = handler.executePost(req, res);
+
+    return res.redirect(redirect);
+});
+
+export default router;

--- a/src/routers/handlers/apply_to_file_options/index.ts
+++ b/src/routers/handlers/apply_to_file_options/index.ts
@@ -1,0 +1,106 @@
+import { Request, Response } from "express";
+import { BaseViewData, GenericHandler, Redirect, ViewModel } from "./../generic";
+import { logger } from "../../../utils/logger";
+import { PrefixedUrls } from "../../../constants";
+import { env } from "../../../config";
+
+/**
+ * Interface for the view data options when applying to a file.
+ * @interface ApplyToFileOptionsViewData
+ * @extends {BaseViewData}
+ * @property {string} applyToRegisterAsLenderLink - The link to apply to register as a lender.
+ * @property {string} filingFeeFieldName - The field name for the filing fee.
+ * @property {typeof FilingFeeOptions} FilingFeeOptions - The options for filing fee.
+ */
+interface ApplyToFileOptionsViewData extends BaseViewData {
+    applyToRegisterAsLenderLink: string
+    filingFeeFieldName: string
+    FilingFeeOptions: typeof FilingFeeOptions
+}
+
+/**
+ * The field name for the filing fee.
+ * @type {string}
+ */
+export const filingFeeFieldName = 'filingFee';
+
+/**
+ * The options for filing fee.
+ * @type {Object}
+ * @property {string} NO - Option for no filing fee.
+ * @property {string} YES - Option for filing fee.
+ */
+export const FilingFeeOptions = {
+    NO: 'no',
+    YES: 'yes'
+};
+
+
+/**
+ * Handler for applying to file options.
+ * @class ApplyToFileOptionsHandler
+ * @extends {GenericHandler<ApplyToFileOptionsViewData>}
+ */
+export class ApplyToFileOptionsHandler extends GenericHandler<ApplyToFileOptionsViewData> {
+    /**
+     * Path to the template for the apply to file options page.
+     * @type {string}
+     */
+    public static templatePath = "router_views/apply_to_file_options/apply_to_file_options_page";
+
+    /**
+     * Get the view data for the apply to file options page.
+     * @param {Request} req - The request object.
+     * @returns {ApplyToFileOptionsViewData} - The view data for the page.
+     */
+    public getViewData(req: Request): ApplyToFileOptionsViewData {
+        const baseViewData = super.getViewData(req);
+
+        return {
+            ...baseViewData,
+            backURL: PrefixedUrls.HOME,
+            title: "Apply to file with Companies House using software",
+            applyToRegisterAsLenderLink: env.APPLICATION_FORM_LINK,
+            filingFeeFieldName,
+            FilingFeeOptions: FilingFeeOptions
+        };
+    }
+
+    /**
+     * Handle GET request to serve the apply to file options page.
+     * @param {Request} req - The request object.
+     * @param {Response} _res - The response object.
+     * @returns {ViewModel<BaseViewData>} - The view model for the page.
+     */
+    public executeGet(req: Request, _res: Response): ViewModel<BaseViewData> {
+        logger.info("GET request to serve the 'apply to file options page'");
+        return {
+            templatePath: ApplyToFileOptionsHandler.templatePath,
+            viewData: this.getViewData(req),
+        };
+    }
+
+    /**
+     * Handle POST request to serve the apply to file options page.
+     * @param {Request} req - The request object.
+     * @param {Response} _res - The response object.
+     * @returns {Redirect} - The redirect object.
+     */
+    public executePost(req: Request, _res: Response): Redirect {
+        logger.info("POST request to serve the 'apply to file options page'");
+
+        const filingFeeResponse = req.body[filingFeeFieldName] as string;
+
+        switch (filingFeeResponse) {
+                case FilingFeeOptions.NO:
+                    logger.debug(`User selected '${FilingFeeOptions.NO}' on the 'what-do-you-need-to-file' page.`);
+                    return { redirect: PrefixedUrls.ENTER_YOUR_DETAILS };
+                case FilingFeeOptions.YES:
+                    logger.debug(`User selected '${FilingFeeOptions.NO}' on the 'what-do-you-need-to-file' page.`);
+                    return { redirect: PrefixedUrls.YOU_CANNOT_USE_THIS_SERVICE };
+                default:
+                    throw new Error(`Invalid field value [${filingFeeResponse}] for field [${filingFeeFieldName}] on the "what-do-you-need-to-file" page.`);
+        }
+    }
+}
+

--- a/src/routers/handlers/generic.ts
+++ b/src/routers/handlers/generic.ts
@@ -33,6 +33,11 @@ export const defaultBaseViewData: Partial<BaseViewData> = {
     pageLinks
 };
 
+
+export interface Redirect {
+    redirect: string
+}
+
 export abstract class GenericHandler<T extends BaseViewData> {
     errorManifest: any;
     private viewData: T;

--- a/src/routers/handlers/you_cannot_use_this_service/index.ts
+++ b/src/routers/handlers/you_cannot_use_this_service/index.ts
@@ -1,0 +1,59 @@
+import { Request, Response } from "express";
+import { logger } from "../../../utils/logger";
+import { BaseViewData, GenericHandler, ViewModel } from "../generic";
+import { env } from "../../../config";
+import { PrefixedUrls } from "../../../constants";
+
+/**
+ * Interface for the view data when the user cannot use the service.
+ * @interface YouCannotUseThisServiceViewData
+ * @extends {BaseViewData}
+ * @property {string} applicationFormLink - The link to the application form.
+ */
+interface YouCannotUseThisServiceViewData extends BaseViewData {
+    applicationFormLink: string
+}
+
+/**
+ * Handler for the case when the user cannot use the service.
+ * @class YouCannotUseThisServiceHandler
+ * @extends {GenericHandler<YouCannotUseThisServiceViewData>}
+ */
+export class YouCannotUseThisServiceHandler extends GenericHandler<YouCannotUseThisServiceViewData> {
+    /**
+     * Path to the template for the "cannot use this service" page.
+     * @type {string}
+     */
+    public static templatePath = "router_views/cannot_use_this_service/cannot_use_this_service_page";
+
+    /**
+     * Get the view data for the "cannot use this service" page.
+     * @param {Request} req - The request object.
+     * @returns {YouCannotUseThisServiceViewData} - The view data for the page.
+     */
+    public getViewData(req: Request): YouCannotUseThisServiceViewData {
+        const baseViewData = super.getViewData(req);
+
+        return {
+            ...baseViewData,
+            backURL: PrefixedUrls.APPLY_TO_FILE_OPTIONS,
+            title: "Apply to file with Companies House using software",
+            applicationFormLink: env.APPLICATION_FORM_LINK
+        };
+    }
+
+    /**
+     * Handle the execution of the "cannot use this service" page.
+     * @param {Request} req - The request object.
+     * @param {Response} _response - The response object.
+     * @returns {ViewModel<YouCannotUseThisServiceViewData>} - The view model for the page.
+     */
+    public execute (req: Request, _response: Response): ViewModel<YouCannotUseThisServiceViewData> {
+        logger.info(`GET request for to serve home page`);
+        return {
+            templatePath: YouCannotUseThisServiceHandler.templatePath,
+            viewData: this.getViewData(req),
+        };
+    }
+}
+

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -1,5 +1,7 @@
 import HomeRouter from "./index.router";
 import HealthCheckRouter from "./healthcheck.router";
 import CheckDetailsRouter from "./check.details.router";
+import ApplyToFileOptionsRouter from "./apply.to.file.options.router";
+import YouCannotUseThisServiceRouter  from "./you.connot.use.this.service.router";
 
-export { HealthCheckRouter, HomeRouter, CheckDetailsRouter };
+export { HealthCheckRouter, HomeRouter, CheckDetailsRouter, ApplyToFileOptionsRouter, YouCannotUseThisServiceRouter };

--- a/src/routers/you.connot.use.this.service.router.ts
+++ b/src/routers/you.connot.use.this.service.router.ts
@@ -1,13 +1,12 @@
 import { Request, Response, Router, NextFunction } from "express";
-import { CheckDetailsHandler } from "./handlers/check_details";
+import { YouCannotUseThisServiceHandler } from "./handlers/you_cannot_use_this_service";
 
 const router: Router = Router();
 
 router.get("/", (req: Request, res: Response, _next: NextFunction) => {
-    const handler = new CheckDetailsHandler();
+    const handler = new YouCannotUseThisServiceHandler();
     const { templatePath, viewData } = handler.execute(req, res);
     res.render(templatePath, viewData);
 });
-
 
 export default router;

--- a/src/views/router_views/apply_to_file_options/apply_to_file_options_page.njk
+++ b/src/views/router_views/apply_to_file_options/apply_to_file_options_page.njk
@@ -1,0 +1,62 @@
+{% extends "layouts/default.njk" %}
+
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block main_content %}
+    <form method="POST" action="{{Urls.APPLY_TO_FILE_OPTIONS}}">
+        {{ govukRadios({
+            name: filingFeeFieldName,
+            fieldset: {
+                legend: {
+                    text: "Do you need to file any accounts or documents that have a filing fee?",
+                    isPageHeading: true,
+                    classes: "govuk-fieldset__legend--l"
+                }
+            },
+            items: [
+                {
+                    value: "no",
+                    html: "No - I only need to file accounts and documents <strong>without a filing fee</strong>",
+                    checked: true
+                },
+                {
+                    value: "yes",
+                    html: "Yes - I need to file accounts and documents <strong>with a filing fee</strong>"
+                }
+            ]
+        }) }}
+    
+
+        {% set details_html %}
+            <p> There is a fee to file accounts for:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>overseas companies </li>
+                <li>community interest companies (CIC)</li>
+            </ul>
+            <p>You should check the documents you need to file. If there is a filing fee, it will say on the document itself. </p>
+        {% endset %}
+
+        {{ govukDetails({
+            summaryText: "Accounts and documents that have a filing fee",
+            html: details_html
+        }) }}
+
+        {% set inset_text_html %}
+            <p>If you need to file electronic charge (mortgage) documents, you will need to <a href="{{ applyToRegisterAsLenderLink }}">apply to register as a lender</a> instead. </p>
+        {% endset %}
+
+        {{ govukInsetText({
+            html: inset_text_html
+        }) }}
+
+        {{ govukButton({
+            type: "submit",
+            text: "Continue"
+        }) }}
+    <form />
+{% endblock %}
+
+

--- a/src/views/router_views/cannot_use_this_service/cannot_use_this_service_page.njk
+++ b/src/views/router_views/cannot_use_this_service/cannot_use_this_service_page.njk
@@ -1,0 +1,13 @@
+{% extends "layouts/default.njk" %}
+
+{% block main_content %}
+    <h1 class="govuk-heading-xl">You need to complete an application form</h1>
+    <p class="govuk-body">If you need to file (any of the following):</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>accounts and documents with a filing fee</li>
+        <li>electronic charge documents</li>
+    </ul>
+    <p class="govuk-body">
+    You will need to <a href="{{applicationFormLink}}" class="govuk-link">complete an application form</a>.
+    </p>
+{% endblock %}

--- a/src/views/router_views/index/home.njk
+++ b/src/views/router_views/index/home.njk
@@ -24,7 +24,7 @@
 
         {{ govukButton({
             text: "Start now",
-            href: "/filter",
+            href: Urls.APPLY_TO_FILE_OPTIONS,
             classes: "govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8",
             isStartButton: true
         }) }}

--- a/test/routers/handlers/apply_to_file_options/apply.to.file.options.unit.ts
+++ b/test/routers/handlers/apply_to_file_options/apply.to.file.options.unit.ts
@@ -1,0 +1,51 @@
+import app from "../../../../src/app";
+import request from "supertest";
+import { PrefixedUrls } from "../../../../src/constants";
+import { FilingFeeOptions, filingFeeFieldName } from "../../../../src/routers/handlers/apply_to_file_options";
+
+describe("apply to file optons page tests", () => {
+    it("should render the apply to file options page", async () => {
+        const resp = await request(app).get(PrefixedUrls.APPLY_TO_FILE_OPTIONS);
+
+        expect(resp.status).toBe(200);
+        expect(resp.text).toContain("Do you need to file any accounts or documents that have a filing fee?");
+    });
+
+
+    it("should redirect to ENTER_YOUR_DETAILS page when 'no' is selected", async () => {
+        const formObj = {};
+        formObj[filingFeeFieldName] = FilingFeeOptions.NO;
+
+        const resp = await request(app)
+            .post(PrefixedUrls.APPLY_TO_FILE_OPTIONS)
+            .send(formObj);
+
+        expect(resp.status).toBe(302);
+        expect(resp.header.location).toBe(PrefixedUrls.ENTER_YOUR_DETAILS);
+    });
+
+    it("should redirect to YOU_CANNOT_USE_THIS_SERVICE page when 'yes' is selected", async () => {
+        const formObj = {};
+        formObj[filingFeeFieldName] = FilingFeeOptions.YES;
+
+        const resp = await request(app)
+            .post(PrefixedUrls.APPLY_TO_FILE_OPTIONS)
+            .send(formObj);
+
+        expect(resp.status).toBe(302);
+        expect(resp.header.location).toBe(PrefixedUrls.YOU_CANNOT_USE_THIS_SERVICE);
+    });
+
+    it("should render error page when form field is neither 'yes' nor 'no'", async () => {
+        const formObj = {};
+        formObj[filingFeeFieldName] = "invalid";
+
+        const resp = await request(app)
+            .post(PrefixedUrls.APPLY_TO_FILE_OPTIONS)
+            .send(formObj);
+
+        expect(resp.status).toBe(500);
+        expect(resp.text).toContain("Internal server error");
+    });
+});
+

--- a/test/routers/handlers/you_cannot_use_this_service/you.canno.use.ths.servce.unit.ts
+++ b/test/routers/handlers/you_cannot_use_this_service/you.canno.use.ths.servce.unit.ts
@@ -1,0 +1,12 @@
+import app from "../../../../src/app";
+import request from "supertest";
+import { PrefixedUrls } from "../../../../src/constants";
+
+describe("you cannot use this service page tests", () => {
+    it("should render the you canot use this service page", async () => {
+        const resp = await request(app).get(PrefixedUrls.YOU_CANNOT_USE_THIS_SERVOCE);
+
+        expect(resp.status).toBe(200);
+        expect(resp.text).toContain("You need to complete an application form");
+    });
+});

--- a/test/routers/handlers/you_cannot_use_this_service/you.cannon.use.ths.servce.unit.ts
+++ b/test/routers/handlers/you_cannot_use_this_service/you.cannon.use.ths.servce.unit.ts
@@ -4,7 +4,7 @@ import { PrefixedUrls } from "../../../../src/constants";
 
 describe("you cannot use this service page tests", () => {
     it("should render the you canot use this service page", async () => {
-        const resp = await request(app).get(PrefixedUrls.YOU_CANNOT_USE_THIS_SERVOCE);
+        const resp = await request(app).get(PrefixedUrls.YOU_CANNOT_USE_THIS_SERVICE);
 
         expect(resp.status).toBe(200);
         expect(resp.text).toContain("You need to complete an application form");


### PR DESCRIPTION
Added the page to select which type of accounts to apply for (fee bearing or not).
Added a page to say you can't use the service for fee bearing accounts and a link to the application form for them.
Added logic to connect the pages. 
If the user selects 'No' the account and documents they want to file don't have a fee, then they proceed to the 'Enter you details' page. 

Both pages that are added are unauthenticated and the user will be required to login before the 'Enter you details' page.

Resolves: [AOAF-283](https://companieshouse.atlassian.net/browse/AOAF-283) 

[AOAF-283]: https://companieshouse.atlassian.net/browse/AOAF-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ