### PR TITLE
Clean

### DIFF
--- a/src/router.dispatch.ts
+++ b/src/router.dispatch.ts
@@ -25,11 +25,6 @@ const routerDispatch = (app: Application) => {
 
     router.use(Urls.CHECK_DETAILS, CheckDetailsRouter);
 
-    // TODO: this endpoint is a dummy authenticated endpoint used for testing AOAF-280. Remove this endpoint once AOAF-280 has completed testing.
-    router.get('/post-sign', (req, res) => {
-        return res.send('Welcome presenter account service');
-    });
-
     app.use(commonTemplateVariablesMiddleware);
     app.use(errorHandler);
     app.use("*", pageNotFound);

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -7,7 +7,7 @@ locals {
   container_port             = "3000" # default port required here until prod docker container is built allowing port change via env var
   docker_repo                = "presenter-account-web"
   lb_listener_rule_priority  = 12
-  lb_listener_paths          = ["/presenter-account/*"]
+  lb_listener_paths          = ["/presenter-account*"]
   healthcheck_path           = "/presenter-account/healthcheck" #healthcheck path for presenter-account-web
   healthcheck_matcher        = "200"
   application_subnet_ids     = data.aws_subnets.application.ids


### PR DESCRIPTION
Just a small cleanup.
- Remove endpoint used for testing authentication functionality before authenticated pages were deployed. 
- Remove trailing slash from LB path. Currently `https://cidev.aws.chdev.org/presenter-account` leads to a 404 since the LB path requires a trailing slash (`https://cidev.aws.chdev.org/presenter-account/`). This PR just removes the trailing slash so `https://cidev.aws.chdev.org/presenter-account` matches. 