### PR TITLE
Fix cookie link

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,7 +26,6 @@ export const env = readEnv(process.env, {
             "https://www.gov.uk/government/organisations/companies-house#org-contacts"
         ),
     COOKIE_DOMAIN: str.describe("Domain for cookies"),
-    COOKIE_LINK: str.describe("Link to cookies").default("http://chs.local/help/cookies"),
     COOKIE_NAME: str.describe("Name for the cookie"),
     COOKIE_SECRET: str.describe("Secret used for cookie encryption"),
     DEVELOPERS_LINK: str

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ export const Urls = {
     ENTER_YOUR_DETAILS: "/enter-your-details",
     CHECK_DETAILS: "/check_details",
     SUBMITTED: "/submitted",
-    YOU_CANNOT_USE_THIS_SERVICE: '/you-cannot-use-this-service'
+    YOU_CANNOT_USE_THIS_SERVICE: "/you-cannot-use-this-service"
 };
 
 export const PrefixedUrls = {
@@ -21,13 +21,13 @@ export const PrefixedUrls = {
     ENTER_YOUR_DETAILS: servicePathPrefix + Urls.ENTER_YOUR_DETAILS,
     CHECK_DETAILS: servicePathPrefix + Urls.CHECK_DETAILS,
     SUBMITTED: servicePathPrefix + Urls.SUBMITTED,
-    YOU_CANNOT_USE_THIS_SERVICE: servicePathPrefix + Urls.YOU_CANNOT_USE_THIS_SERVICE
+    YOU_CANNOT_USE_THIS_SERVICE: servicePathPrefix + Urls.YOU_CANNOT_USE_THIS_SERVICE,
+    COOKIES: "/help/cookies"
 };
 
 export const ExternalUrls = {
     ABILITY_NET: env.ABILITY_NET_LINK,
     CONTACT_US: env.CONTACT_US_LINK,
-    COOKIES: env.COOKIE_LINK,
     DEVELOPERS: env.DEVELOPERS_LINK,
     FEEDBACK: env.FEEDBACK_URL,
     OPEN_GOVERNMENT_LICENSE: env.OPEN_GOVERNMENT_LICENSE_LINK,

--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -8,7 +8,7 @@
             <a class="govuk-footer__link" data-track-category="footerClicked" data-track-action="supportLink" data-track-label="/policies" data-track-options="{&quot;dimension29&quot;:&quot;Policies&quot;}" href="{{ExternalUrls.POLICIES}}">Policies</a>
           </li>
           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" data-track-category="footerClicked" data-track-action="supportLink" data-track-label="/cookies" data-track-options="{&quot;dimension29&quot;:&quot;Cookies&quot;}" href="{{ExternalUrls.COOKIES}}">Cookies</a>
+            <a class="govuk-footer__link" data-track-category="footerClicked" data-track-action="supportLink" data-track-label="/cookies" data-track-options="{&quot;dimension29&quot;:&quot;Cookies&quot;}" href="{{Urls.COOKIES}}">Cookies</a>
           </li>
           <li class="govuk-footer__inline-list-item">
             <a class="govuk-footer__link" data-track-category="footerClicked" data-track-action="supportLink" data-track-label="/contact" data-track-options="{&quot;dimension29&quot;:&quot;Contact&quot;}" href="{{ExternalUrls.CONTACT_US}}">Contact Us</a>


### PR DESCRIPTION
The cookie link was eroneously set to http://chs.local/help/cookies.
This PR fixes that by setting it be relative so it's correct in all environments.