### PR TITLE
Fix titles

### DIFF
--- a/src/routers/handlers/apply_to_file_options/index.ts
+++ b/src/routers/handlers/apply_to_file_options/index.ts
@@ -59,7 +59,7 @@ export class ApplyToFileOptionsHandler extends GenericHandler<ApplyToFileOptions
         return {
             ...baseViewData,
             backURL: PrefixedUrls.HOME,
-            title: "Apply to file with Companies House using software",
+            title: "What do you want to do? - Apply for a Companies House online filing presenter account - GOV.UK",
             applyToRegisterAsLenderLink: env.APPLICATION_FORM_LINK,
             filingFeeFieldName,
             FilingFeeOptions: FilingFeeOptions

--- a/src/routers/handlers/confirmation/index.ts
+++ b/src/routers/handlers/confirmation/index.ts
@@ -16,8 +16,8 @@ export class ConfirmationHandler extends GenericHandler<ConfirmationViewData> {
 
         return {
             ...baseViewData,
-            backURL: PrefixedUrls.CHECK_DETAILS,
-            title: "Apply to file with Companies House using software"
+            title: "Application submitted - Apply for a Companies House online filing presenter account - GOV.UK",
+            backURL: PrefixedUrls.CHECK_DETAILS
         };
     }
 

--- a/src/routers/handlers/generic.ts
+++ b/src/routers/handlers/generic.ts
@@ -7,7 +7,7 @@ import { Request } from "express";
 
 export interface BaseViewData {
     errors: any
-    title: string
+    title: string 
     isSignedIn: boolean
     backURL: string | null
     servicePathPrefix: string
@@ -23,7 +23,8 @@ export const defaultBaseViewData: Partial<BaseViewData> = {
     servicePathPrefix: servicePathPrefix,
     Urls: PrefixedUrls,
     ExternalUrls: ExternalUrls,
-    userEmail: null
+    userEmail: null,
+    title: 'Apply to file with Companies House using software'
 } as const;
 
 

--- a/src/routers/handlers/index/home.ts
+++ b/src/routers/handlers/index/home.ts
@@ -10,8 +10,8 @@ export class HomeHandler extends GenericHandler<BaseViewData> {
 
         return {
             ...baseViewData,
-            backURL: null,
-            title: "Apply to file with Companies House using software",
+            title: "Apply to file with Companies House using software - GOV.UK",
+            backURL: null
         };
     }
 

--- a/src/routers/handlers/you_cannot_use_this_service/index.ts
+++ b/src/routers/handlers/you_cannot_use_this_service/index.ts
@@ -36,8 +36,8 @@ export class YouCannotUseThisServiceHandler extends GenericHandler<YouCannotUseT
 
         return {
             ...baseViewData,
+            title: "You cannot use this service - Apply for a Companies House online filing presenter account - GOV.UK",
             backURL: PrefixedUrls.APPLY_TO_FILE_OPTIONS,
-            title: "Apply to file with Companies House using software",
             applicationFormLink: env.APPLICATION_FORM_LINK
         };
     }

--- a/src/views/partials/banner.njk
+++ b/src/views/partials/banner.njk
@@ -134,5 +134,5 @@
   </a>
 </div>
 <div class="govuk-header__content">
-  <a href="{{Urls.HOME}}" class="govuk-header__link govuk-header__link--service-name">Presenter Account</a>
+  <a href="{{Urls.HOME}}" class="govuk-header__link govuk-header__link--service-name">Apply to file with Companies House using software</a>
 </div>

--- a/src/views/router_views/check_details/check_details.njk
+++ b/src/views/router_views/check_details/check_details.njk
@@ -2,10 +2,6 @@
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% block pageTitle %}
-  Apply to file with Companies House using software
-{% endblock %}
-
 {% block main_content %}
     <h1 class="govuk-heading-l">Check your answers before submitting your application</h1>
 


### PR DESCRIPTION
Small tweaks to page titles to match the prototype.

- Fixes the service banenr to show 'Apply to file with Companies House using software' instead of 'Presenter Account'.
- Fixes the page titles.