### PR TITLE
Delete session on successful submission

### DIFF
--- a/src/routers/handlers/check_details/index.ts
+++ b/src/routers/handlers/check_details/index.ts
@@ -7,7 +7,7 @@ import {
 } from "./../generic";
 import { logger } from "../../../utils/logger";
 import { type Address } from "private-api-sdk-node/src/services/presenter-account/types";
-import { getPresenterAccountDetails } from "../../../utils/session";
+import { getPresenterAccountDetails, cleanSessionOnSubmit } from "../../../utils/session";
 import { PrefixedUrls } from "../../../constants";
 import { createOauthPrivateApiClient } from "../../../service/api.client.service";
 import { Result, failure } from "@companieshouse/api-sdk-node/dist/services/result";
@@ -75,6 +75,9 @@ export class CheckDetailsHandler extends GenericHandler<CheckDetailsViewData> {
             const errorMessage = `Error submitting details to the presenter-account-api: ${submitResult.value.message}`;
             logger.error(errorMessage);
             return new Error(errorMessage);
+        } else {
+            // On successful submission, clean up the session
+            cleanSessionOnSubmit(req);
         }
 
         return {

--- a/src/routers/handlers/confirmation/index.ts
+++ b/src/routers/handlers/confirmation/index.ts
@@ -16,8 +16,7 @@ export class ConfirmationHandler extends GenericHandler<ConfirmationViewData> {
 
         return {
             ...baseViewData,
-            title: "Application submitted - Apply for a Companies House online filing presenter account - GOV.UK",
-            backURL: PrefixedUrls.CHECK_DETAILS
+            title: "Application submitted - Apply for a Companies House online filing presenter account - GOV.UK"
         };
     }
 

--- a/src/routers/handlers/confirmation/index.ts
+++ b/src/routers/handlers/confirmation/index.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from "express";
 import { logger } from "../../../utils/logger";
 import { BaseViewData, GenericHandler, ViewModel } from "../generic";
-import { PrefixedUrls } from "../../../constants";
 
 interface ConfirmationViewData extends BaseViewData {
 }

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -50,3 +50,7 @@ export function getPresenterAccountDetailsOrDefault(req: Request) {
     }
     return details;
 }
+
+export function cleanSessionOnSubmit(req: Request) {
+    req.session?.setExtraData(PRESENTER_ACCOUNT_SESSION_KEY, undefined);
+}

--- a/test/routers/handlers/check_details/check.details.unit.ts
+++ b/test/routers/handlers/check_details/check.details.unit.ts
@@ -96,7 +96,7 @@ describe("check details tests", () => {
 
         await request(app)
             .post(PrefixedUrls.CHECK_DETAILS);
-        
+
         expect(session.getExtraData[PRESENTER_ACCOUNT_SESSION_KEY]).toBe(undefined);
     });
 

--- a/test/routers/handlers/check_details/check.details.unit.ts
+++ b/test/routers/handlers/check_details/check.details.unit.ts
@@ -86,6 +86,20 @@ describe("check details tests", () => {
             .expect("Location", PrefixedUrls.CONFIRMATION);
     });
 
+    it("Should clean the session after successfully submitting the Presenter Account details", async () => {
+        session.setExtraData(
+            PRESENTER_ACCOUNT_SESSION_KEY,
+            examplePresenterAccountDetails
+        );
+
+        mockSubmitPresenterAccountDetails.mockReturnValue(success(undefined));
+
+        await request(app)
+            .post(PrefixedUrls.CHECK_DETAILS);
+        
+        expect(session.getExtraData[PRESENTER_ACCOUNT_SESSION_KEY]).toBe(undefined);
+    });
+
     it("Should display an error page when there is an error in submitting the Presenter Account details", async () => {
         const details = examplePresenterAccountDetails;
         mockSubmitPresenterAccountDetails.mockImplementation(() => {


### PR DESCRIPTION
This pr adds a clean up phase the submission of presenter account details. If the submission is successful the data in the session is deleted so that the use can use the service again without their old data being populated. Also included is the removal of the back button on the confirmation screen as you shouldn't be able to go back there and re do the submission.