### PR TITLE
Small fixes

### DIFF
--- a/src/views/partials/signout-bar.njk
+++ b/src/views/partials/signout-bar.njk
@@ -1,10 +1,8 @@
 {% if userEmail %}
     {% set email = userEmail | default("Not signed in") %}
-    <ul class="signout-bar" id="navigation">
-        <li class="content-email" id="signed-in-user">{{email}}</li>
-        <li class="content">
-            <a class="govuk-link" href="{{ExternalUrls.SIGNOUT}}" data-event-id="sign-out-button-selected" id="user-signout">Sign Out</a>
-        </li>
-    </ul>
-    <script src="//{{ cdn.host }}/javascripts/app/session-timeout.js"></script>
+    <div class="signout-bar" id="navigation">
+        <span class="content-email" id="signed-in-user">{{email}}</span>
+        <a class="govuk-link" href="{{ExternalUrls.SIGNOUT}}" data-event-id="sign-out-button-selected" id="user-signout">Sign Out</a>
+    </div>
+<script src="//{{ cdn.host }}/javascripts/app/session-timeout.js"></script>
 {% endif %}

--- a/src/views/partials/signout-bar.njk
+++ b/src/views/partials/signout-bar.njk
@@ -1,10 +1,8 @@
 {% if userEmail %}
     {% set email = userEmail | default("Not signed in") %}
-    <ul class="signout-bar" id="navigation">
-        <li class="content-email" id="signed-in-user">{{email}}</li>
-        <li class="content">
-            <a class="govuk-link" href="{{navigation.signOut.href}}" data-event-id="sign-out-button-selected" id="user-signout">Sign Out</a>
-        </li>
-    </ul>
+    <div class="signout-bar" id="navigation">
+        <span class="content-email" id="signed-in-user">{{email}}</span>
+        <a class="govuk-link" href="{{Urls.SIGNOUT}}" data-event-id="sign-out-button-selected" id="user-signout">Sign Out</a>
+    </div>
     <script src="//{{ cdn.host }}/javascripts/app/session-timeout.js"></script>
 {% endif %}

--- a/src/views/router_views/check_details/check_details.njk
+++ b/src/views/router_views/check_details/check_details.njk
@@ -6,16 +6,14 @@
     <h1 class="govuk-heading-l">Check your answers before submitting your application</h1>
 
     {% macro renderAddress(address) %}
-        <dd class="govuk-summary-list__value">
-            {{ address.premises }}<br>
-            {{ address.addressLine1 }}<br>
-            {% if address.addressLine2 %}
-                {{ address.addressLine2 }}<br>
-            {% endif %}
-            {{ address.townOrCity }}<br>
-            {{ address.country }}<br>
-            {{ address.postCode }}
-        </dd>
+        {{ address.premises }}<br>
+        {{ address.addressLine1 }}<br>
+        {% if address.addressLine2 %}
+            {{ address.addressLine2 }}<br>
+        {% endif %}
+        {{ address.townOrCity }}<br>
+        {{ address.country }}<br>
+        {{ address.postCode }}
     {% endmacro %}
 
 

--- a/src/views/router_views/confirmation/confirmation.njk
+++ b/src/views/router_views/confirmation/confirmation.njk
@@ -17,7 +17,7 @@
         <li>presenter code</li>
     </ul>
 
-    <p class="govuk-body">If you have not received an email within an hour, check your spam or junk folder. If it still has not arrived, you should <a href="{{ Urls.HOME }}">submit another application</a>.&nbsp;&nbsp;</p>
+    <p class="govuk-body">This can take up to an hour. If you have not received an email after an hour, check your junk folder.</p>
 
     <p class="govuk-body">You must keep your presenter ID and code secure. You will need them to file using software. </p>
 {% endblock %}


### PR DESCRIPTION
PR to fix a few small issues:
1. Fix a voiceover issue with the "Signout" link that read "list two items" because it was implemented using an un-ordered list. This is fixed by implementing with a div and span instead.
2. Fix the address alignment on the check details page due to mistakenly adding another table column when rendering the address.
3. Update the confirmation page content to remove a link.