### PR TITLE
Clean the session when a new user logs in

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,3 @@
-import { Address, Details, Name } from "private-api-sdk-node/src/services/presenter-account/types";
 import { env } from "./config";
 
 export const servicePathPrefix = "/presenter-account";
@@ -285,19 +284,3 @@ export const countries = [
     { value: 'Zambia', text: 'Zambia' },
     { value: 'Zimbabwe', text: 'Zimbabwe' },
 ] as const;
-
-const defaultAddress = {
-    premises: '',
-    postCode: '',
-    country: '',
-    addressLine1: '',
-    townOrCity: ''
-} as Address;
-
-export const defaultDetails = {
-    email: '',
-    name: { forename: '', surname: '' } as Name,
-    userId: '',
-    createdDate: '',
-    address: defaultAddress
-} as Details;

--- a/src/middleware/user.validate.middleware.ts
+++ b/src/middleware/user.validate.middleware.ts
@@ -1,0 +1,25 @@
+import { Handler } from "express";
+import { cleanSession, getPresenterAccountDetails } from "../utils/session";
+import { PrefixedUrls } from "../constants";
+
+/**
+ * Validate User checks the user logged in is the user that
+ * created the original session, if not clean the session
+ * and redirect back to the start page.
+ *
+ * @param req http request
+ * @param res http response
+ * @param next the next handler in the chain
+ */
+export const validateUserMiddleware: Handler = (req, res, next) => {
+
+    const userLoggedIn = req.session?.data?.signin_info?.user_profile?.id;
+    const sessionUser = getPresenterAccountDetails(req)?.userId;
+
+    if (userLoggedIn && sessionUser && userLoggedIn !== sessionUser) {
+        cleanSession(req);
+        res.redirect(PrefixedUrls.HOME);
+    } else {
+        next();
+    }
+};

--- a/src/router.dispatch.ts
+++ b/src/router.dispatch.ts
@@ -5,6 +5,7 @@ import { sessionMiddleware } from "./middleware/session.middleware";
 import { authenticationMiddleware } from "./middleware/authentication.middleware";
 import { commonTemplateVariablesMiddleware } from "./middleware/common.variables.middleware";
 import { Urls, servicePathPrefix } from "./constants";
+import { validateUserMiddleware } from "./middleware/user.validate.middleware";
 
 const routerDispatch = (app: Application) => {
 
@@ -19,6 +20,7 @@ const routerDispatch = (app: Application) => {
     // ------------- Enable login redirect -----------------
     const userAuthRegex = /^\/.+/;
     router.use(userAuthRegex, authenticationMiddleware);
+    router.use(userAuthRegex, validateUserMiddleware);
     router.use(Urls.ENTER_YOUR_DETAILS, EnterYourDetailsRouter);
     router.use(Urls.CHECK_DETAILS, CheckDetailsRouter);
     router.use(Urls.CONFIRMATION, ConfirmationRouter);

--- a/src/routers/handlers/check_details/index.ts
+++ b/src/routers/handlers/check_details/index.ts
@@ -7,7 +7,7 @@ import {
 } from "./../generic";
 import { logger } from "../../../utils/logger";
 import { type Address } from "private-api-sdk-node/src/services/presenter-account/types";
-import { getPresenterAccountDetails, cleanSessionOnSubmit } from "../../../utils/session";
+import { getPresenterAccountDetails, cleanSession } from "../../../utils/session";
 import { PrefixedUrls } from "../../../constants";
 import { createOauthPrivateApiClient } from "../../../service/api.client.service";
 import { Result, failure } from "@companieshouse/api-sdk-node/dist/services/result";
@@ -77,7 +77,7 @@ export class CheckDetailsHandler extends GenericHandler<CheckDetailsViewData> {
             return new Error(errorMessage);
         } else {
             // On successful submission, clean up the session
-            cleanSessionOnSubmit(req);
+            cleanSession(req);
         }
 
         return {

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,4 +1,3 @@
-import { defaultDetails } from "./../constants";
 import { Request } from "express";
 import { isDetails } from "private-api-sdk-node/dist/services/presenter-account/types";
 import { type Details } from "private-api-sdk-node/src/services/presenter-account/types";
@@ -19,7 +18,7 @@ export function setPresenterAccountDetails(req: Request, details: Details) {
     req.session?.setExtraData(PRESENTER_ACCOUNT_SESSION_KEY, details);
 }
 
-export function populatePresenterAccountDetails(req: Request, details: Details): Details{
+export function populatePresenterAccountDetails(req: Request): Details {
     const user_profile = req.session?.data?.signin_info?.user_profile;
     const createdDate = (new Date()).toISOString();
 
@@ -28,29 +27,32 @@ export function populatePresenterAccountDetails(req: Request, details: Details):
     }
 
     const { email, id, forename, surname } = user_profile;
-    const detailObject = { ...details,
+    const detailObject = {
         email: email,
         userId: id,
         name: { forename, surname },
-        createdDate
-    };
+        createdDate,
+        address: {
+            premises: '',
+            postCode: '',
+            country: '',
+            addressLine1: '',
+            townOrCity: ''
+        }
+    } as Details;
 
-    if (isDetails(detailObject)){
-        return detailObject;
-    }
-
-    throw new Error("Presenter account detail object format not supported");
+    return detailObject;
 }
 
 export function getPresenterAccountDetailsOrDefault(req: Request) {
     let details = getPresenterAccountDetails(req);
     if (details === undefined) {
-        details = populatePresenterAccountDetails(req, defaultDetails);
+        details = populatePresenterAccountDetails(req);
         setPresenterAccountDetails(req, details);
     }
     return details;
 }
 
-export function cleanSessionOnSubmit(req: Request) {
+export function cleanSession(req: Request) {
     req.session?.setExtraData(PRESENTER_ACCOUNT_SESSION_KEY, undefined);
 }

--- a/test/mocks/session.middleware.mock.ts
+++ b/test/mocks/session.middleware.mock.ts
@@ -4,11 +4,14 @@ jest.mock("../../src/middleware/session.middleware");
 import { NextFunction, Request, Response } from "express";
 import { sessionMiddleware } from "../../src/middleware/session.middleware";
 import { Session } from "@companieshouse/node-session-handler";
+import { getSessionRequest } from "./session.mock";
 
 // get handle on mocked function
 export const mockSessionMiddleware = sessionMiddleware as jest.Mock;
 
-export const session = new Session();
+export let session = new Session();
+
+export const mockSession = () => session = getSessionRequest();
 
 // tell the mock what to return
 mockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {

--- a/test/routers/handlers/check_details/check.details.unit.ts
+++ b/test/routers/handlers/check_details/check.details.unit.ts
@@ -1,5 +1,5 @@
 import { mockSubmitPresenterAccountDetails } from "../../../mocks/mock.presenter.account.service.mock";
-import { session } from "../../../mocks/session.middleware.mock";
+import { session, mockSession } from "../../../mocks/session.middleware.mock";
 
 import app from "../../../../src/app";
 import request from "supertest";
@@ -110,5 +110,21 @@ describe("check details tests", () => {
             .post(PrefixedUrls.CHECK_DETAILS)
             .send(details)
             .expect(500);
+    });
+
+    it("Should redirect to the home page if the user details do not match", async () => {
+        // Use a mock session with a user id value
+        mockSession();
+        session.setExtraData(
+            PRESENTER_ACCOUNT_SESSION_KEY,
+            examplePresenterAccountDetails
+        );
+
+        mockSubmitPresenterAccountDetails.mockReturnValue(success(undefined));
+
+        await request(app)
+            .get(PrefixedUrls.CHECK_DETAILS)
+            .expect(302)
+            .expect("Location", PrefixedUrls.HOME);
     });
 });


### PR DESCRIPTION
This pr adds a new middleware "validateUserMiddleware" that checks the user logged in to the user that is stored in the session. If they do not match the session is cleaned and the user is returned to the home page. This is to fix a bug where logging out and immediately logging in with a new account allowed users to see the previous user data.

Also removed the default session and set it to create a clean new session object everytime a session is created.

**Resolves:**
[AOAF-313](https://companieshouse.atlassian.net/browse/AOAF-313)

[AOAF-313]: https://companieshouse.atlassian.net/browse/AOAF-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ