### PR TITLE
Create flag for the presenter account web

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import routerDispatch from "./router.dispatch";
 import cookieParser from "cookie-parser";
 import { env } from './config';
 import { ExternalUrls, PrefixedUrls, Urls, servicePathPrefix } from "./constants";
+import { featureFlagMiddleware } from "./middleware/feature.flag.middleware";
 
 const app = express();
 
@@ -50,6 +51,7 @@ app.use(express.urlencoded({ extended: false }));
 
 // apply middleware
 app.use(cookieParser());
+app.use(featureFlagMiddleware);
 
 // Unhandled errors
 app.use((err: any, req: Request, res: Response, _next: NextFunction) => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -35,6 +35,8 @@ export const env = readEnv(process.env, {
     DEVELOPERS_LINK: str
         .describe("Link for developers")
         .default("https://developer.companieshouse.gov.uk/"),
+    FEATURE_FLAG_PRESENTER_ACCOUNT_280224: bool
+        .describe("Feature flag for enabling presenter account"),
     FEEDBACK_URL: str
         .describe("Link for the user to give feedback on the service")
         .default("https://www.gov.uk/contact/govuk"),

--- a/src/middleware/feature.flag.middleware.ts
+++ b/src/middleware/feature.flag.middleware.ts
@@ -1,5 +1,6 @@
 import { Handler } from "express";
 import { env } from '../config';
+import { logger } from "../utils/logger";
 
 /**
  * Feature flag for presenter account. Default value is true.
@@ -8,8 +9,9 @@ import { env } from '../config';
  * @param next the next handler in the chain
  */
 export const featureFlagMiddleware: Handler = (_req, res, next) => {
-    console.log(env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224);
-    if(!env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224){
+
+    if(!env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224) {
+        logger.info("Attempt to reach site while the feature flag is disabled");
         res.render("partials/error_404");
     }
     next();

--- a/src/middleware/feature.flag.middleware.ts
+++ b/src/middleware/feature.flag.middleware.ts
@@ -1,0 +1,16 @@
+import { Handler } from "express";
+import { env } from '../config';
+
+/**
+ * Feature flag for presenter account. Default value is true.
+ * @param req http request
+ * @param res http response
+ * @param next the next handler in the chain
+ */
+export const featureFlagMiddleware: Handler = (_req, res, next) => {
+    console.log(env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224);
+    if(!env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224){
+        res.render("partials/error_404");
+    }
+    next();
+};

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -10,4 +10,5 @@ export default () => {
     process.env.COOKIE_SECRET = "123456789012345678901234";
     process.env.INTERNAL_API_URL = "http://api.chs.local";
     process.env.NUNJUCKS_LOADER_WATCH = "false";
+    process.env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224 = "true";
 };

--- a/test/middleware/feature.flag.middleware.unit.ts
+++ b/test/middleware/feature.flag.middleware.unit.ts
@@ -1,21 +1,48 @@
-import { featureFlagMiddleware } from "../../src/middleware/feature.flag.middleware";
 import { Response, Request } from "express";
 
 describe("Feature flag middleware test", () => {
+
     it("should render the 404 page if feature flag is off", async () => {
+
         process.env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224 = "false";
 
-        const res = mockres();
+        const { featureFlagMiddleware } = await import("../../src/middleware/feature.flag.middleware");
 
-        featureFlagMiddleware({} as unknown as Request,res,()=>{});
+        const res = mockResponse();
+        const next = jest.fn();
+
+        featureFlagMiddleware(mockRequest(), res, next);
 
         expect(res.render).toHaveBeenCalledWith("partials/error_404");
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call the next function if feature flag is on", async () => {
+
+        process.env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224 = "true";
+
+        const { featureFlagMiddleware } = await import("../../src/middleware/feature.flag.middleware");
+
+        const res = mockResponse();
+        const next = jest.fn();
+
+        featureFlagMiddleware(mockRequest(), res, next);
+
+        expect(res.render).toHaveBeenCalledTimes(0);
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    afterEach(() => {
+        jest.resetModules();
     });
 });
 
-function mockres(){
+function mockResponse() {
     return {
-     render:jest.fn()
+        render:jest.fn()
     } as unknown as Response;
-    
+}
+
+function mockRequest() {
+    return {} as unknown as Request;
 }

--- a/test/middleware/feature.flag.middleware.unit.ts
+++ b/test/middleware/feature.flag.middleware.unit.ts
@@ -1,0 +1,21 @@
+import { featureFlagMiddleware } from "../../src/middleware/feature.flag.middleware";
+import { Response, Request } from "express";
+
+describe("Feature flag middleware test", () => {
+    it("should render the 404 page if feature flag is off", async () => {
+        process.env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224 = "false";
+
+        const res = mockres();
+
+        featureFlagMiddleware({} as unknown as Request,res,()=>{});
+
+        expect(res.render).toHaveBeenCalledWith("partials/error_404");
+    });
+});
+
+function mockres(){
+    return {
+     render:jest.fn()
+    } as unknown as Response;
+    
+}


### PR DESCRIPTION
This pr adds a feature flag to the presenter account service so it can be released without going live to customers.

**Resolves:**
- [AOAF-328](https://companieshouse.atlassian.net/browse/AOAF-328)

[AOAF-328]: https://companieshouse.atlassian.net/browse/AOAF-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ