### PR TITLE
Move feature flag check to after healthcheck

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,6 @@ import routerDispatch from "./router.dispatch";
 import cookieParser from "cookie-parser";
 import { env } from './config';
 import { ExternalUrls, PrefixedUrls, Urls, servicePathPrefix } from "./constants";
-import { featureFlagMiddleware } from "./middleware/feature.flag.middleware";
 
 const app = express();
 
@@ -51,7 +50,6 @@ app.use(express.urlencoded({ extended: false }));
 
 // apply middleware
 app.use(cookieParser());
-app.use(featureFlagMiddleware);
 
 // Unhandled errors
 app.use((err: any, req: Request, res: Response, _next: NextFunction) => {

--- a/src/middleware/feature.flag.middleware.ts
+++ b/src/middleware/feature.flag.middleware.ts
@@ -10,9 +10,10 @@ import { logger } from "../utils/logger";
  */
 export const featureFlagMiddleware: Handler = (_req, res, next) => {
 
-    if(!env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224) {
+    if (!env.FEATURE_FLAG_PRESENTER_ACCOUNT_280224) {
         logger.info("Attempt to reach site while the feature flag is disabled");
         res.render("partials/error_404");
+    } else {
+        next();
     }
-    next();
 };

--- a/src/router.dispatch.ts
+++ b/src/router.dispatch.ts
@@ -6,14 +6,18 @@ import { authenticationMiddleware } from "./middleware/authentication.middleware
 import { commonTemplateVariablesMiddleware } from "./middleware/common.variables.middleware";
 import { Urls, servicePathPrefix } from "./constants";
 import { validateUserMiddleware } from "./middleware/user.validate.middleware";
+import { featureFlagMiddleware } from "./middleware/feature.flag.middleware";
 
 const routerDispatch = (app: Application) => {
 
     const router = Router();
     app.use(servicePathPrefix, router);
 
-    router.use(Urls.HOME, HomeRouter);
     router.use(Urls.HEALTHCHECK, HealthCheckRouter);
+
+    router.use(featureFlagMiddleware);
+
+    router.use(Urls.HOME, HomeRouter);
 
     router.use("/", sessionMiddleware);
 

--- a/test/middleware/feature.flag.middleware.unit.ts
+++ b/test/middleware/feature.flag.middleware.unit.ts
@@ -14,7 +14,7 @@ describe("Feature flag middleware test", () => {
         featureFlagMiddleware(mockRequest(), res, next);
 
         expect(res.render).toHaveBeenCalledWith("partials/error_404");
-        expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledTimes(0);
     });
 
     it("should call the next function if feature flag is on", async () => {
@@ -39,7 +39,7 @@ describe("Feature flag middleware test", () => {
 
 function mockResponse() {
     return {
-        render:jest.fn()
+        render: jest.fn()
     } as unknown as Response;
 }
 


### PR DESCRIPTION
This pr moves the feature flag middleware to the router so that it is only checked after the healthcheck. Also moved the next to an else to stop a bug where multiple renders were called.

**Required for:**
- [AOAF-328](https://companieshouse.atlassian.net/browse/AOAF-328)

[AOAF-328]: https://companieshouse.atlassian.net/browse/AOAF-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ