### PR TITLE
Fix cacahing issue

### DIFF
--- a/src/middleware/no.cache.middleware.ts
+++ b/src/middleware/no.cache.middleware.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Middleware to prevent caching by setting appropriate HTTP headers.
+ * @param req - The incoming request.
+ * @param res - The outgoing response.
+ * @param next - The next middleware function in the application’s request-response cycle.
+ */
+export function noCacheMiddleware(_req: Request, res: Response, next: NextFunction): void {
+    res.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+    res.set('Pragma', 'no-cache');
+    res.set('Expires', '0');
+    res.set('Surrogate-Control', 'no-store');
+
+    next();
+}

--- a/src/middleware/require.presenter.account.details.middleware.ts
+++ b/src/middleware/require.presenter.account.details.middleware.ts
@@ -1,0 +1,35 @@
+import { PrefixedUrls } from "../constants";
+import { NextFunction, Request, Response } from "express";
+import { logger } from "../utils/logger";
+import { cleanSession, getPresenterAccountDetails } from "../utils/session";
+
+/**
+ * Middleware to ensure that presenter account details are present in the session.
+ *
+ * This middleware checks for presenter account details in the user's session. If the details are not found,
+ * or an error occurs while retrieving them, the middleware will log the error, clear the session, and redirect
+ * the user to the home page.
+ *
+ * @param {Request} req - The express request object, which should contain the session information.
+ * @param {Response} res - The express response object, used to redirect if necessary.
+ * @param {NextFunction} next - The next middleware function in the express stack to be executed.
+ */
+export function requirePresenterAccountDetailsMiddleware(req: Request, res: Response, next: NextFunction) {
+    const pageIfDetailsAreIncorrect = PrefixedUrls.HOME;
+
+    try {
+        const details = getPresenterAccountDetails(req);
+        if (details === undefined) {
+            logger.error(`Unable to find required presenter account details in session. Redirecting to hoem page.`);
+            return res.redirect(pageIfDetailsAreIncorrect);
+        }
+
+        // Presenter account details are in session and are correct type.
+        next();
+    } catch (error) {
+        logger.error(`Presenter account detaails in session are of incorrect type. Clearing details and redirecting to the home spage for a new submission.`);
+        cleanSession(req);
+
+        return res.redirect(pageIfDetailsAreIncorrect);
+    }
+}

--- a/src/routers/check.details.router.ts
+++ b/src/routers/check.details.router.ts
@@ -1,7 +1,14 @@
 import { NextFunction, Request, Response, Router } from "express";
 import { CheckDetailsHandler } from "./handlers/check_details";
 import { handleExceptions } from "../utils/async.handler";
-const router: Router = Router();
+import { noCacheMiddleware } from "../middleware/no.cache.middleware";
+
+const router = Router();
+
+// Prevent caching on this page.
+// If the user presses the back button, it will render the page as it apeared previously using
+// cached HTML even though the details could have already been submitted and session cleared.
+router.use(noCacheMiddleware);
 
 router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new CheckDetailsHandler();

--- a/src/routers/check.details.router.ts
+++ b/src/routers/check.details.router.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response, Router } from "express";
 import { CheckDetailsHandler } from "./handlers/check_details";
 import { handleExceptions } from "../utils/async.handler";
 import { noCacheMiddleware } from "../middleware/no.cache.middleware";
+import { requirePresenterAccountDetailsMiddleware } from "../middleware/require.presenter.account.details.middleware";
 
 const router = Router();
 
@@ -10,7 +11,7 @@ const router = Router();
 // cached HTML even though the details could have already been submitted and session cleared.
 router.use(noCacheMiddleware);
 
-router.get("/", handleExceptions(async (req: Request, res: Response) => {
+router.get("/", requirePresenterAccountDetailsMiddleware, handleExceptions(async (req: Request, res: Response) => {
     const handler = new CheckDetailsHandler();
     const { templatePath, viewData } = handler.executeGet(req, res);
     res.render(templatePath, viewData);

--- a/src/routers/enter.your.details.router.ts
+++ b/src/routers/enter.your.details.router.ts
@@ -2,8 +2,14 @@ import { Request, Response, Router, NextFunction } from "express";
 import { EnterYourDetailsHandler } from "./handlers/enter_your_details";
 import { formValidation } from "./../validation/enter.your.details.validation";
 import { handleExceptions } from "../utils/async.handler";
+import { noCacheMiddleware } from "../middleware/no.cache.middleware";
 
-const router: Router = Router();
+const router = Router();
+
+// Prevent caching on this page.
+// If the user presses the back button, it will render the page as it apeared previously using
+// cached HTML even though the details could have already been submitted and session cleared.
+router.use(noCacheMiddleware);
 
 router.get("/", handleExceptions( async (req: Request, res: Response, _next: NextFunction) => {
     const handler = new EnterYourDetailsHandler();

--- a/test/routers/handlers/check_details/check.details.unit.ts
+++ b/test/routers/handlers/check_details/check.details.unit.ts
@@ -23,6 +23,21 @@ describe("check details tests", () => {
         expect(resp.status).toBe(200);
     });
 
+    it("Should not cache the HTMl on this page", async () => {
+        session.setExtraData(
+            PRESENTER_ACCOUNT_SESSION_KEY,
+            examplePresenterAccountDetails
+        );
+
+        await request(app)
+            .get(PrefixedUrls.CHECK_DETAILS)
+            .expect(200)
+            .expect('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+            .expect('Pragma', 'no-cache')
+            .expect('Expires', '0')
+            .expect('Surrogate-Control', 'no-store');
+    });
+
     it("Should display the correct heading on the Check Details page", async () => {
         session.setExtraData(
             PRESENTER_ACCOUNT_SESSION_KEY,

--- a/test/routers/handlers/check_details/check.details.unit.ts
+++ b/test/routers/handlers/check_details/check.details.unit.ts
@@ -127,6 +127,20 @@ describe("check details tests", () => {
             .expect(500);
     });
 
+    it("Should redirect to the home page if the presenter account details are not in the session", async () => {
+        // Use a mock session with a user id value
+        mockSession();
+        session.setExtraData(
+            PRESENTER_ACCOUNT_SESSION_KEY,
+            undefined
+        );
+
+        await request(app)
+            .get(PrefixedUrls.CHECK_DETAILS)
+            .expect(302)
+            .expect("Location", PrefixedUrls.HOME);
+    });
+
     it("Should redirect to the home page if the user details do not match", async () => {
         // Use a mock session with a user id value
         mockSession();

--- a/test/routers/handlers/enter-your-details/enter.your.details.unit.ts
+++ b/test/routers/handlers/enter-your-details/enter.your.details.unit.ts
@@ -35,6 +35,21 @@ describe("validate form fields", () => {
         expect(resp.text).toContain("What is your correspondence address?");
     });
 
+    it("Should not cache the HTMl on this page", async () => {
+        session.setExtraData(
+            PRESENTER_ACCOUNT_SESSION_KEY,
+            examplePresenterAccountDetails
+        );
+
+        await request(app)
+            .get(PrefixedUrls.ENTER_YOUR_DETAILS)
+            .expect(200)
+            .expect('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+            .expect('Pragma', 'no-cache')
+            .expect('Expires', '0')
+            .expect('Surrogate-Control', 'no-store');
+    });
+
     it("should display errors for missing mandatory fields",  async () => {
         session.setExtraData(
             PRESENTER_ACCOUNT_SESSION_KEY,


### PR DESCRIPTION
Fixes a bug where, when the user presses the back button in the browser after they have submitted details, renders the cached page. 

This PR fixes that by Adding headers to prevemt the browser from caching the `enter your detaisl` or `check your details` pages.

Additionally, it adds middleware that redirects to the home page if there is no presenter account details in the session. This middleare runs on the `check your details` page. This is required because when the details are submitted, the presenter account details are deleted from the session. If the user goes back to the `check your details` page they would get  a service unavailable page. With the middleware, they will be redirected to the home page. 
This isn't a problem on the `enter your details` page as that page creates new details if non are found.


Resolves: [AOAF-336](https://companieshouse.atlassian.net/browse/AOAF-336)

[AOAF-336]: https://companieshouse.atlassian.net/browse/AOAF-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ